### PR TITLE
Move images into build folder next to collection item

### DIFF
--- a/app/Listeners/ImagesNextToBuiltFiles.php
+++ b/app/Listeners/ImagesNextToBuiltFiles.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use DOMDocument;
+use TightenCo\Jigsaw\Collection\CollectionItem;
+use TightenCo\Jigsaw\Jigsaw;
+
+class ImagesNextToBuiltFiles
+{
+    public function handle(Jigsaw $jigsaw)
+    {
+        collect($jigsaw->getPages())
+            ->filter(fn($page) => $page instanceof CollectionItem)
+            ->each(function (CollectionItem $item) use ($jigsaw) {
+                // Read the output file
+                $itemFolderName = $item->getUrl();
+                $html = $jigsaw->readOutputFile($itemFolderName.'/index.html');
+
+                // Scan the HTML for collection-specific images.
+                $document = new DOMDocument();
+                @$document->loadHTML($html);
+                $container = $document->getElementById('post-content');
+
+                /** @var \DOMElement[] $images */
+                $images = $container->getElementsByTagName('img');
+
+                foreach ($images as $image) {
+                    if ($image->hasAttribute('keeplocation')) {
+                        continue;
+                    }
+
+                    $originalImageLocation = $image->getAttribute('src');
+
+                    // Move the image into the post's output folder.
+                    $newImageLocation = $itemFolderName.'/'.basename($originalImageLocation);
+                    $jigsaw->writeOutputFile($newImageLocation, $jigsaw->readOutputFile($originalImageLocation));
+
+                    // Change the src of the image to the new path.
+                    $image->setAttribute('src', $newImageLocation);
+                }
+
+                // Write the new HTML into the output file.
+                $jigsaw->writeOutputFile($itemFolderName.'/index.html', $document->saveHTML());
+            });
+    }
+}

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Listeners\ImagesNextToBuiltFiles;
 use TightenCo\Jigsaw\Jigsaw;
 
 /** @var \Illuminate\Container\Container $container */
@@ -15,3 +16,4 @@ use TightenCo\Jigsaw\Jigsaw;
  *     // Your code here
  * });
  */
+$events->afterBuild(ImagesNextToBuiltFiles::class);

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,10 @@
 {
     "require": {
         "tightenco/jigsaw": "^1.6"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
     }
 }

--- a/source/_layouts/main.blade.php
+++ b/source/_layouts/main.blade.php
@@ -68,11 +68,11 @@
     <body class="font-sans text-base text-gray-900 antialiased border-8 border-gray-300 bg-white min-h-screen relative | dark:bg-gray-800 dark:border-gray-900 lg:border-0">
         @include('_partials.header')
 
-        <div class="container mx-auto">
+        <main id="post-content" class="container mx-auto">
             <div class="mx-auto w-full py-4 px-6 | lg:w-3/5 md:py-12 lg:px-0">
                 @yield('content')
             </div>
-        </div>
+        </main>
 
         @include('_partials.footer')
     </body>


### PR DESCRIPTION
When any post (or "collection item", in Jigsaw terms) contains an `<img>` tag _without the `keeplocation` attribute_, it will be moved into the item's folder.

For example, say I write a post titled "This Is My Post". The HTML is built and put into `this-is-my-post/index.html`. If the post contains an image, it will be copied to `this-is-my-post/image.jpg` instead of the default `/assets/images/image.jpg`.