### PR TITLE
Remove use of deprecation method in highlight.js

### DIFF
--- a/source/_assets/js/main.js
+++ b/source/_assets/js/main.js
@@ -2,4 +2,4 @@ import hljs from "highlight.js";
 
 hljs.registerLanguage('dockerfile', require('highlight.js/lib/languages/dockerfile'));
 
-hljs.initHighlightingOnLoad();
+hljs.highlightAll();


### PR DESCRIPTION
The `hljs.initHighlightingOnLoad()` method has been deprecated as of [highlight.js `10.6.0`](https://github.com/highlightjs/highlight.js/releases/tag/10.6.0) and its use has been replaced with `hljs.highlightAll()`.