### PR TITLE
Remove duplicate primary keys

### DIFF
--- a/database/migrations/2025_02_10_185259_create_articles_table.php
+++ b/database/migrations/2025_02_10_185259_create_articles_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('articles', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->ulid()->unique();
             $table->string('title');
             $table->string('slug')->unique();

--- a/database/migrations/2025_02_11_090405_create_venues_table.php
+++ b/database/migrations/2025_02_11_090405_create_venues_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('venues', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->ulid()->unique();
             $table->string('name');
             $table->string('country');

--- a/database/migrations/2025_02_11_090553_create_concerts_table.php
+++ b/database/migrations/2025_02_11_090553_create_concerts_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('concerts', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->ulid()->unique();
             $table->string('title');
             $table->string('tour_name');

--- a/database/migrations/2025_10_18_150225_create_artists_table.php
+++ b/database/migrations/2025_10_18_150225_create_artists_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('artists', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->ulid()->unique();
             $table->string('name');
             $table->timestamps();

--- a/database/migrations/2025_12_26_130836_create_blog_posts_table.php
+++ b/database/migrations/2025_12_26_130836_create_blog_posts_table.php
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('blog_posts', function (Blueprint $table) {
-            $table->id()->primary();
+            $table->id();
             $table->ulid()->unique();
             $table->string('title');
             $table->string('slug')->unique();


### PR DESCRIPTION
`->id()` already makes it a primary key. This kills the SQLite.